### PR TITLE
Fixed the connection profile path bug when Windows started up

### DIFF
--- a/pkg/util/xfile/file.go
+++ b/pkg/util/xfile/file.go
@@ -18,6 +18,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -155,6 +156,9 @@ func substr(s string, pos, length int) string {
 }
 
 func getParentDirectory(dirctory string) string {
+	if runtime.GOOS == "windows" {
+		dirctory = strings.Replace(dirctory, "\\", "/", -1)
+	}
 	return substr(dirctory, 0, strings.LastIndex(dirctory, "/"))
 }
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/douyu/jupiter/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Fixed the connection profile path bug when Windows started up

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #5 
### Describe how you did it
The getParentDirectory function adds a judgment to the Windows system

### Describe how to verify it
Use the Windows system to start juno-agent. The command is juno-agent --config=../../ config/config-live. toml

### Special notes for reviews