### PR TITLE
xgin->websocket，允许websocket跨域

### DIFF
--- a/example/http/gin/main.go
+++ b/example/http/gin/main.go
@@ -16,11 +16,13 @@ package main
 
 import (
 	"log"
+	"net/http"
 
 	"github.com/douyu/jupiter"
 	"github.com/douyu/jupiter/pkg/server/xgin"
 	"github.com/douyu/jupiter/pkg/xlog"
 	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
 )
 
 func main() {
@@ -69,6 +71,16 @@ func (eng *Engine) serveHTTP() error {
 				break
 			}
 		}
-	}))
+	}, handleCheckOrigin))
 	return eng.Serve(server)
+}
+
+//handleCheckOrigin 允许websocket跨域
+//error:request origin not allowed by Upgrader.CheckOrigin
+func handleCheckOrigin(ws *xgin.WebSocket) {
+	ws.Upgrader = &websocket.Upgrader{
+		CheckOrigin: func(r *http.Request) bool {
+			return true
+		},
+	}
 }

--- a/example/http/gin_ws_cors/config.toml
+++ b/example/http/gin_ws_cors/config.toml
@@ -1,0 +1,2 @@
+[jupiter.server.http]
+    port = 9099


### PR DESCRIPTION
### Describe what this PR does / why we need it
xgin->websocket 例子`jupiter/example/http/gin/main.go`不允许跨域，报以下错误：
`upgrade:websocket: request origin not allowed by Upgrader.CheckOrigin`

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #167 

### Describe how you did it
通过预留方法WebSocketOption，设置websocket允许跨域

### Describe how to verify it
使用websocket在线测试工具，测试得到websocket允许跨域
