### PR TITLE
add default cron parser

### DIFF
--- a/pkg/worker/xcron/config.go
+++ b/pkg/worker/xcron/config.go
@@ -104,6 +104,9 @@ func (config *Config) WithParser(parser Parser) Config {
 func (config Config) Build() *Cron {
 	if config.WithSeconds {
 		config.parser = cron.NewParser(cron.Second | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
+	} else {
+		// default parser
+		config.parser = cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
 	}
 
 	if config.ConcurrentDelay > 0 { // 延迟


### PR DESCRIPTION
cron默认没有解析器，需要设置withSeconds为true，默认情况下，cron解析器应该解析到分钟。