### PR TITLE
fix the path separator is a backslash on windows

### DIFF
--- a/tools/jupiter/common/util.go
+++ b/tools/jupiter/common/util.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -18,6 +19,9 @@ func GetModPath(projectPath string) (modPath string) {
 			mod := xregexp.RegexpReplace(`module\s+(?P<name>[\S]+)`, string(content), "$name")
 			name := strings.TrimPrefix(filepath.Dir(projectPath), dir)
 			name = strings.TrimPrefix(name, string(os.PathSeparator))
+			if runtime.GOOS == "windows" {
+				name = strings.ReplaceAll(name, "\\", "/")
+			}
 			if name == "" {
 				return fmt.Sprintf("%s/", mod)
 			}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/douyu/jupiter/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Windows用jupiter脚手架在go.mod的多层子级目录下创建new demo时，import的路径会带有windows路径的反斜杠
比如 go.mod 在最外层，同级有一个目录为 A, 在windows的A/B/C里的C目录 下创建new demo时生成的代码import路径出错

### Does this pull request fix one issue?
None

### Describe how you did it
jupiter new demo

### Describe how to verify it

### Special notes for reviews