### PR TITLE
support for customizing service-address in registry info

### DIFF
--- a/pkg/server/governor/config.go
+++ b/pkg/server/governor/config.go
@@ -18,6 +18,9 @@ type Config struct {
 	Network string `json:"network" toml:"network"`
 	logger  *xlog.Logger
 	Enable  bool
+
+	// ServiceAddress service address in registry info, default to 'Host:Port'
+	ServiceAddress string
 }
 
 // StdConfig represents Standard gRPC Server config

--- a/pkg/server/governor/server.go
+++ b/pkg/server/governor/server.go
@@ -55,9 +55,14 @@ func (s *Server) GracefulStop(ctx context.Context) error {
 
 //Info ..
 func (s *Server) Info() *server.ServiceInfo {
+	serviceAddr := s.listener.Addr().String()
+	if s.Config.ServiceAddress != "" {
+		serviceAddr = s.Config.ServiceAddress
+	}
+
 	info := server.ApplyOptions(
 		server.WithScheme("http"),
-		server.WithAddress(s.listener.Addr().String()),
+		server.WithAddress(serviceAddr),
 		server.WithKind(constant.ServiceGovernor),
 	)
 	// info.Name = info.Name + "." + ModName

--- a/pkg/server/xecho/config.go
+++ b/pkg/server/xecho/config.go
@@ -36,6 +36,8 @@ type Config struct {
 	Debug         bool
 	DisableMetric bool
 	DisableTrace  bool
+	// ServiceAddress service address in registry info, default to 'Host:Port'
+	ServiceAddress string
 
 	SlowQueryThresholdInMilli int64
 

--- a/pkg/server/xecho/handler.go
+++ b/pkg/server/xecho/handler.go
@@ -25,7 +25,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/labstack/echo/v4"
 	"google.golang.org/grpc/metadata"
-	status "google.golang.org/grpc/status"
+	"google.golang.org/grpc/status"
 )
 
 // ProtoError ...

--- a/pkg/server/xecho/server.go
+++ b/pkg/server/xecho/server.go
@@ -81,9 +81,14 @@ func (s *Server) GracefulStop(ctx context.Context) error {
 
 // Info returns server info, used by governor and consumer balancer
 func (s *Server) Info() *server.ServiceInfo {
+	serviceAddr := s.listener.Addr().String()
+	if s.config.ServiceAddress != "" {
+		serviceAddr = s.config.ServiceAddress
+	}
+
 	info := server.ApplyOptions(
 		server.WithScheme("http"),
-		server.WithAddress(s.listener.Addr().String()),
+		server.WithAddress(serviceAddr),
 		server.WithKind(constant.ServiceProvider),
 	)
 	// info.Name = info.Name + "." + ModName

--- a/pkg/server/xgin/config.go
+++ b/pkg/server/xgin/config.go
@@ -35,6 +35,8 @@ type Config struct {
 	Mode          string
 	DisableMetric bool
 	DisableTrace  bool
+	// ServiceAddress service address in registry info, default to 'Host:Port'
+	ServiceAddress string
 
 	SlowQueryThresholdInMilli int64
 

--- a/pkg/server/xgin/server.go
+++ b/pkg/server/xgin/server.go
@@ -89,9 +89,14 @@ func (s *Server) GracefulStop(ctx context.Context) error {
 
 // Info returns server info, used by governor and consumer balancer
 func (s *Server) Info() *server.ServiceInfo {
+	serviceAddr := s.listener.Addr().String()
+	if s.config.ServiceAddress != "" {
+		serviceAddr = s.config.ServiceAddress
+	}
+
 	info := server.ApplyOptions(
 		server.WithScheme("http"),
-		server.WithAddress(s.listener.Addr().String()),
+		server.WithAddress(serviceAddr),
 		server.WithKind(constant.ServiceProvider),
 	)
 	// info.Name = info.Name + "." + ModName

--- a/pkg/server/xgoframe/config.go
+++ b/pkg/server/xgoframe/config.go
@@ -33,6 +33,8 @@ type Config struct {
 	Debug         bool
 	DisableMetric bool
 	DisableTrace  bool
+	// ServiceAddress service address in registry info, default to 'Host:Port'
+	ServiceAddress string
 
 	SlowQueryThresholdInMilli int64
 

--- a/pkg/server/xgoframe/server.go
+++ b/pkg/server/xgoframe/server.go
@@ -16,11 +16,9 @@ package xgoframe
 
 import (
 	"context"
-	"strconv"
 
 	"github.com/douyu/jupiter/pkg/constant"
 	"github.com/douyu/jupiter/pkg/xlog"
-
 	//"github.com/douyu/jupiter/pkg/ecode"
 	//"github.com/douyu/jupiter/pkg/xlog"
 	"github.com/douyu/jupiter/pkg/server"
@@ -37,7 +35,7 @@ type Server struct {
 func newServer(config *Config) *Server {
 	s := new(Server)
 	serve := g.Server()
-	serve.SetPort(config.Port)
+	serve.SetAddr(config.Address())
 
 	s.Server = serve
 	s.config = config
@@ -69,9 +67,14 @@ func (s *Server) GracefulStop(ctx context.Context) error {
 
 //Info ..
 func (s *Server) Info() *server.ServiceInfo {
+	serviceAddr := s.config.Address()
+	if s.config.ServiceAddress != "" {
+		serviceAddr = s.config.ServiceAddress
+	}
+
 	info := server.ApplyOptions(
 		server.WithScheme("http"),
-		server.WithAddress(s.config.Host+":"+strconv.Itoa(s.config.Port)),
+		server.WithAddress(serviceAddr),
 		server.WithKind(constant.ServiceProvider),
 	)
 	return &info

--- a/pkg/server/xgrpc/config.go
+++ b/pkg/server/xgrpc/config.go
@@ -38,9 +38,12 @@ type Config struct {
 	DisableMetric bool
 	// SlowQueryThresholdInMilli, request will be colored if cost over this threshold value
 	SlowQueryThresholdInMilli int64
-	serverOptions             []grpc.ServerOption
-	streamInterceptors        []grpc.StreamServerInterceptor
-	unaryInterceptors         []grpc.UnaryServerInterceptor
+	// ServiceAddress service address in registry info, default to 'Host:Port'
+	ServiceAddress string
+
+	serverOptions      []grpc.ServerOption
+	streamInterceptors []grpc.StreamServerInterceptor
+	unaryInterceptors  []grpc.UnaryServerInterceptor
 
 	logger *xlog.Logger
 }

--- a/pkg/server/xgrpc/server_test.go
+++ b/pkg/server/xgrpc/server_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/douyu/jupiter/pkg/constant"
-	"github.com/douyu/jupiter/pkg/server"
 	"github.com/douyu/jupiter/pkg/xlog"
 	"github.com/smartystreets/goconvey/convey"
 	"google.golang.org/grpc"
@@ -30,10 +29,9 @@ import (
 
 func TestServer_Serve(t *testing.T) {
 	type fields struct {
-		Server     *grpc.Server
-		listener   net.Listener
-		Config     *Config
-		serverInfo *server.ServiceInfo
+		Server   *grpc.Server
+		listener net.Listener
+		Config   *Config
 	}
 	tests := []struct {
 		name    string
@@ -45,10 +43,9 @@ func TestServer_Serve(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &Server{
-				Server:     tt.fields.Server,
-				listener:   tt.fields.listener,
-				Config:     tt.fields.Config,
-				serverInfo: tt.fields.serverInfo,
+				Server:   tt.fields.Server,
+				listener: tt.fields.listener,
+				Config:   tt.fields.Config,
 			}
 			if err := s.Serve(); (err != nil) != tt.wantErr {
 				t.Errorf("Server.Serve() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/douyu/jupiter/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
 support for customizing service-address in registry info

支持自定义服务注册信息中的服务地址，用于服务访问地址和服务Listen的地址不一致的情况

### Does this pull request fix one issue?
NONE
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Add `ServiceAddress` field to `xecho.Config`, `xgrpc.Config`, `xgin.Config`, `xgoframe.Config`

### Describe how to verify it
1. start a `xecho/xgrpc/xgin/xgoframe` server with `ServiceAddress` set
2. check etcd key

### Special notes for reviews
NONE