### PR TITLE
fix get remote config error

### DIFF
--- a/pkg/datasource/http/yasee.go
+++ b/pkg/datasource/http/yasee.go
@@ -68,18 +68,8 @@ func NewDataSource(addr string, enableWatch bool) *yaseeDataSource {
 
 // ReadConfig ...
 func (y *yaseeDataSource) ReadConfig() ([]byte, error) {
-	// 检查watch 如果watch为真，走长轮询逻辑
-	switch y.enableWatch {
-	case true:
-		if y.data == "" {
-			content, err := y.getConfigInner(y.addr, y.enableWatch)
-			return []byte(content), err
-		}
-		return []byte(y.data), nil
-	default:
-		content, err := y.getConfigInner(y.addr, y.enableWatch)
-		return []byte(content), err
-	}
+	content, err := y.getConfigInner(y.addr, false)
+	return []byte(content), err
 }
 
 // IsConfigChanged ...


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/douyu/jupiter/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
修复应用启动获取远程配置时失败的错误

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #212 
### Describe how you did it
修改pkg/datasource/http/yasee.go

func (y *yaseeDataSource) ReadConfig() ([]byte, error) {
	 检查watch 如果watch为真，走长轮询逻辑
	switch y.enableWatch {
	case true:
		return []byte(y.data), nil
	default:
		content, err := y.getConfigInner(y.addr, y.enableWatch)
		return []byte(content), err
	}
}
为

func (y *yaseeDataSource) ReadConfig() ([]byte, error) {
	content, err := y.getConfigInner(y.addr, false)
	return []byte(content), err
}

### Describe how to verify it


### Special notes for reviews