### PR TITLE
fix: enable etcdClient refresh token when invalid

### DIFF
--- a/pkg/client/etcdv3/client.go
+++ b/pkg/client/etcdv3/client.go
@@ -18,15 +18,14 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"github.com/coreos/etcd/clientv3/concurrency"
 	"io/ioutil"
 	"strings"
 	"time"
 
-	"github.com/douyu/jupiter/pkg/ecode"
-
 	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/coreos/etcd/mvcc/mvccpb"
+	"github.com/douyu/jupiter/pkg/ecode"
 	"github.com/douyu/jupiter/pkg/xlog"
 	grpcprom "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"google.golang.org/grpc"
@@ -47,8 +46,8 @@ func newClient(config *Config) *Client {
 		DialKeepAliveTimeout: 3 * time.Second,
 		DialOptions: []grpc.DialOption{
 			grpc.WithBlock(),
-			grpc.WithUnaryInterceptor(grpcprom.UnaryClientInterceptor),
-			grpc.WithStreamInterceptor(grpcprom.StreamClientInterceptor),
+			grpc.WithChainUnaryInterceptor(grpcprom.UnaryClientInterceptor),
+			grpc.WithChainStreamInterceptor(grpcprom.StreamClientInterceptor),
 		},
 		AutoSyncInterval: config.AutoSyncInterval,
 	}


### PR DESCRIPTION


<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/douyu/jupiter/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
目前etcdClient的实现中，在启动账密验证时，不能自动刷新token。
跟踪代码，发现是`grpc.WithUnaryInterceptor(grpcprom.UnaryClientInterceptor)`
覆盖了自动刷新token的`grpc.WithUnaryInterceptor(c.unaryClientInterceptor(c.lg, withMax(defaultUnaryMaxRetries), rrBackoff))`。
最后导致在遇到token失效时，不能自动刷新token。

可能修复这里的使用 https://github.com/douyu/juno-agent/blob/263a5e1f6a043044672578338e1a20268bb4bd2a/pkg/proxy/confProxy/etcd/etcd.go#L303

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
该变更使用`WithChainUnaryInterceptor`替代`WithUnaryInterceptor`，
改为使用链式调用，避免原来的替代。

### Describe how to verify it
链接一个开启账密认证的etcd(etcd3.4 --auth-token-ttl=30)。间隔一段时间去Get/Put。

### Special notes for reviews