### PR TITLE
optimize xcolor

### DIFF
--- a/pkg/util/xcolor/string_darwin.go
+++ b/pkg/util/xcolor/string_darwin.go
@@ -30,31 +30,30 @@ func RandomColor() string {
 }
 
 // Yellow ...
-func Yellow(msg string) string {
-	return fmt.Sprintf("\x1b[33m%s\x1b[0m", msg)
+func Yellow(msg string, arg ...interface{}) string {
+	return sprint(YellowColor, msg, arg...)
 }
 
 // Red ...
-func Red(msg string) string {
-	return fmt.Sprintf("\x1b[31m%s\x1b[0m", msg)
-}
-
-// Redf ...
-func Redf(msg string, arg interface{}) string {
-	return fmt.Sprintf("\x1b[31m%s\x1b[0m %+v\n", msg, arg)
+func Red(msg string, arg ...interface{}) string {
+	return sprint(RedColor, msg, arg...)
 }
 
 // Blue ...
-func Blue(msg string) string {
-	return fmt.Sprintf("\x1b[34m%s\x1b[0m", msg)
+func Blue(msg string, arg ...interface{}) string {
+	return sprint(BlueColor, msg, arg...)
 }
 
 // Green ...
-func Green(msg string) string {
-	return fmt.Sprintf("\x1b[32m%s\x1b[0m", msg)
+func Green(msg string, arg ...interface{}) string {
+	return sprint(GreenColor, msg, arg...)
 }
 
-// Greenf ...
-func Greenf(msg string, arg interface{}) string {
-	return fmt.Sprintf("\x1b[32m%s\x1b[0m %+v\n", msg, arg)
+// sprint
+func sprint(colorValue int, msg string, arg ...interface{}) string {
+	if arg != nil {
+		return fmt.Sprintf("\x1b[%dm%s\x1b[0m %+v", colorValue, msg, arrToTransform(arg))
+	} else {
+		return fmt.Sprintf("\x1b[%dm%s\x1b[0m", colorValue, msg)
+	}
 }

--- a/pkg/util/xcolor/string_linux.go
+++ b/pkg/util/xcolor/string_linux.go
@@ -30,31 +30,30 @@ func RandomColor() string {
 }
 
 // Yellow ...
-func Yellow(msg string) string {
-	return fmt.Sprintf("\x1b[33m%s\x1b[0m", msg)
+func Yellow(msg string, arg ...interface{}) string {
+	return sprint(YellowColor, msg, arg...)
 }
 
 // Red ...
-func Red(msg string) string {
-	return fmt.Sprintf("\x1b[31m%s\x1b[0m", msg)
-}
-
-// Redf ...
-func Redf(msg string, arg interface{}) string {
-	return fmt.Sprintf("\x1b[31m%s\x1b[0m %+v\n", msg, arg)
+func Red(msg string, arg ...interface{}) string {
+	return sprint(RedColor, msg, arg...)
 }
 
 // Blue ...
-func Blue(msg string) string {
-	return fmt.Sprintf("\x1b[34m%s\x1b[0m", msg)
+func Blue(msg string, arg ...interface{}) string {
+	return sprint(BlueColor, msg, arg...)
 }
 
 // Green ...
-func Green(msg string) string {
-	return fmt.Sprintf("\x1b[32m%s\x1b[0m", msg)
+func Green(msg string, arg ...interface{}) string {
+	return sprint(GreenColor, msg, arg...)
 }
 
-// Greenf ...
-func Greenf(msg string, arg interface{}) string {
-	return fmt.Sprintf("\x1b[32m%s\x1b[0m %+v\n", msg, arg)
+// sprint
+func sprint(colorValue int, msg string, arg ...interface{}) string {
+	if arg != nil {
+		return fmt.Sprintf("\x1b[%dm%s\x1b[0m %+v", colorValue, msg, arrToTransform(arg))
+	} else {
+		return fmt.Sprintf("\x1b[%dm%s\x1b[0m", colorValue, msg)
+	}
 }

--- a/pkg/util/xcolor/string_windows.go
+++ b/pkg/util/xcolor/string_windows.go
@@ -30,31 +30,30 @@ func RandomColor() string {
 }
 
 // Yellow ...
-func Yellow(msg string) string {
-	return fmt.Sprintf("%s", msg)
+func Yellow(msg string, arg ...interface{}) string {
+	return sprint(msg, arg...)
 }
 
 // Red ...
-func Red(msg string) string {
-	return fmt.Sprintf("%s", msg)
-}
-
-// Redf ...
-func Redf(msg string, arg interface{}) string {
-	return fmt.Sprintf("%s %+v\n", msg, arg)
+func Red(msg string, arg ...interface{}) string {
+	return sprint(msg, arg...)
 }
 
 // Blue ...
-func Blue(msg string) string {
-	return fmt.Sprintf("%s", msg)
+func Blue(msg string, arg ...interface{}) string {
+	return sprint(msg, arg...)
 }
 
 // Green ...
-func Green(msg string) string {
-	return fmt.Sprintf("%s", msg)
+func Green(msg string, arg ...interface{}) string {
+	return sprint(msg, arg...)
 }
 
-// Greenf ...
-func Greenf(msg string, arg interface{}) string {
-	return fmt.Sprintf("%s %+v\n", msg, arg)
+// sprint ...
+func sprint(msg string, arg ...interface{}) string {
+	if arg != nil {
+		return fmt.Sprintf("%s %+v\n", msg, arrToTransform(arg))
+	} else {
+		return fmt.Sprintf("%s", msg)
+	}
 }

--- a/pkg/util/xcolor/util.go
+++ b/pkg/util/xcolor/util.go
@@ -1,0 +1,25 @@
+package xcolor
+
+import "fmt"
+
+const (
+	RedColor = iota + 31
+	GreenColor
+	YellowColor
+	BlueColor
+)
+
+// array transform
+func arrToTransform(arg []interface{}) interface{} {
+	var res interface{}
+
+	for _, v := range arg {
+		if res != nil {
+			res = fmt.Sprintf("%v %v", res, v)
+		} else {
+			res = v
+		}
+	}
+
+	return res
+}

--- a/pkg/util/xcolor/xcolor_test.go
+++ b/pkg/util/xcolor/xcolor_test.go
@@ -1,0 +1,11 @@
+package xcolor
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestBlue(t *testing.T) {
+	fmt.Println(Blue("hello "))
+	fmt.Println(Blue("hello ", "world"))
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

print one color to distinguish two different funcs, which is not very useful for developers. If you need to add other colors, you also need to declare two funcs, which is not very good from a design perspective.This PR further optimizes xcolor to improve the developer experience

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

Combine and optimize functions


### Describe how to verify it
fmt.Println(xcolor.Red("hello")) -> fmt.Println(xcolor.Red("hello"))
hello              ->        hello
fmt.Println(xcolor.Red("hello", "world")) -> fmt.Println(xcolor.Redf("hello", "world"))
hello world   ->     hello world




### Special notes for reviews