### PR TITLE
fix: incorrect conversion between integer types

### DIFF
--- a/pkg/util/xstring/string.go
+++ b/pkg/util/xstring/string.go
@@ -31,7 +31,7 @@ func Addr2Hex(str string) (string, error) {
 	}
 
 	ip := net.ParseIP(ipStr).To4()
-	port, err := strconv.Atoi(portStr)
+	port, err := strconv.ParseUint(portStr, 10, 16)
 	if err != nil {
 		return "", nil
 	}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/douyu/jupiter/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
将int64转化为uint16的时候可能会发生越界，应该采用这种PraseUint的方法并且指定比特位数为16

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews