### PR TITLE
feat: update xecho access log with trace id

### DIFF
--- a/pkg/client/rocketmq/push_consumer.go
+++ b/pkg/client/rocketmq/push_consumer.go
@@ -116,7 +116,8 @@ func (cc *PushConsumer) RegisterSingleMessage(f func(context.Context, *primitive
 					semconv.MessagingRocketmqMessageTagKey.String(msg.GetTags()),
 				)
 
-				ctx = xlog.NewContext(ctx, xlog.Default(), span.SpanContext().TraceID().String())
+				ctx = xlog.NewContextWithDefaultLogger(ctx, xlog.Default(), span.SpanContext().TraceID().String())
+				ctx = xlog.NewContextWithJupiterLogger(ctx, xlog.Jupiter(), span.SpanContext().TraceID().String())
 
 				defer span.End()
 			}

--- a/pkg/client/rocketmq/push_consumer.go
+++ b/pkg/client/rocketmq/push_consumer.go
@@ -116,8 +116,8 @@ func (cc *PushConsumer) RegisterSingleMessage(f func(context.Context, *primitive
 					semconv.MessagingRocketmqMessageTagKey.String(msg.GetTags()),
 				)
 
-				ctx = xlog.NewContextWithDefaultLogger(ctx, xlog.Default(), span.SpanContext().TraceID().String())
-				ctx = xlog.NewContextWithJupiterLogger(ctx, xlog.Jupiter(), span.SpanContext().TraceID().String())
+				ctx = xlog.NewContext(ctx, xlog.Default(), span.SpanContext().TraceID().String())
+				ctx = xlog.NewContext(ctx, xlog.Jupiter(), span.SpanContext().TraceID().String())
 
 				defer span.End()
 			}

--- a/pkg/server/xecho/config.go
+++ b/pkg/server/xecho/config.go
@@ -106,7 +106,7 @@ func (config *Config) Build() (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
-	server.Use(recoverMiddleware(config.logger, config.SlowQueryThresholdInMilli))
+	server.Use(recoverMiddleware(config.SlowQueryThresholdInMilli))
 
 	if !config.DisableMetric {
 		server.Use(metricServerInterceptor())

--- a/pkg/server/xecho/middleware.go
+++ b/pkg/server/xecho/middleware.go
@@ -39,13 +39,14 @@ func extractAID(c echo.Context) string {
 }
 
 // RecoverMiddleware ...
-func recoverMiddleware(logger *xlog.Logger, slowQueryThresholdInMilli int64) echo.MiddlewareFunc {
+func recoverMiddleware(slowQueryThresholdInMilli int64) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(ctx echo.Context) (err error) {
 			var beg = time.Now()
 			var fields = make([]xlog.Field, 0, 8)
 
 			defer func() {
+				logger := xlog.FromContext(ctx.Request().Context())
 				fields = append(fields, xlog.FieldCost(time.Since(beg)))
 				if rec := recover(); rec != nil {
 					switch rec := rec.(type) {

--- a/pkg/server/xecho/middleware.go
+++ b/pkg/server/xecho/middleware.go
@@ -112,7 +112,7 @@ func traceServerInterceptor() echo.MiddlewareFunc {
 			ctx, span := tracer.Start(c.Request().Context(), c.Request().URL.Path, propagation.HeaderCarrier(c.Request().Header), trace.WithAttributes(attrs...))
 			span.SetAttributes(semconv.HTTPServerAttributesFromHTTPRequest(pkg.Name(), c.Request().URL.Path, c.Request())...)
 
-			ctx = xlog.NewContext(ctx, xlog.Default(), span.SpanContext().TraceID().String())
+			ctx = xlog.NewContext(ctx, xlog.Jupiter(), span.SpanContext().TraceID().String())
 
 			c.SetRequest(c.Request().WithContext(ctx))
 			defer span.End()

--- a/pkg/server/xecho/middleware.go
+++ b/pkg/server/xecho/middleware.go
@@ -112,8 +112,8 @@ func traceServerInterceptor() echo.MiddlewareFunc {
 			ctx, span := tracer.Start(c.Request().Context(), c.Request().URL.Path, propagation.HeaderCarrier(c.Request().Header), trace.WithAttributes(attrs...))
 			span.SetAttributes(semconv.HTTPServerAttributesFromHTTPRequest(pkg.Name(), c.Request().URL.Path, c.Request())...)
 
-			ctx = xlog.NewContextWithDefaultLogger(ctx, xlog.Default(), span.SpanContext().TraceID().String())
-			ctx = xlog.NewContextWithJupiterLogger(ctx, xlog.Jupiter(), span.SpanContext().TraceID().String())
+			ctx = xlog.NewContext(ctx, xlog.Default(), span.SpanContext().TraceID().String())
+			ctx = xlog.NewContext(ctx, xlog.Jupiter(), span.SpanContext().TraceID().String())
 
 			c.SetRequest(c.Request().WithContext(ctx))
 			defer span.End()

--- a/pkg/server/xgrpc/interceptor.go
+++ b/pkg/server/xgrpc/interceptor.go
@@ -93,7 +93,8 @@ func NewTraceUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 			span.End()
 		}()
 
-		ctx = xlog.NewContext(ctx, xlog.Default(), span.SpanContext().TraceID().String())
+		ctx = xlog.NewContextWithDefaultLogger(ctx, xlog.Default(), span.SpanContext().TraceID().String())
+		ctx = xlog.NewContextWithJupiterLogger(ctx, xlog.Jupiter(), span.SpanContext().TraceID().String())
 
 		return handler(ctx, req)
 	}
@@ -135,7 +136,8 @@ func NewTraceStreamServerInterceptor() grpc.StreamServerInterceptor {
 		ctx, span := tracer.Start(ss.Context(), operation, xtrace.MetadataReaderWriter(md), trace.WithAttributes(attrs...))
 		defer span.End()
 
-		ctx = xlog.NewContext(ctx, xlog.Default(), span.SpanContext().TraceID().String())
+		ctx = xlog.NewContextWithDefaultLogger(ctx, xlog.Default(), span.SpanContext().TraceID().String())
+		ctx = xlog.NewContextWithJupiterLogger(ctx, xlog.Jupiter(), span.SpanContext().TraceID().String())
 
 		return handler(srv, contextedServerStream{
 			ServerStream: ss,

--- a/pkg/server/xgrpc/interceptor.go
+++ b/pkg/server/xgrpc/interceptor.go
@@ -93,8 +93,8 @@ func NewTraceUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 			span.End()
 		}()
 
-		ctx = xlog.NewContextWithDefaultLogger(ctx, xlog.Default(), span.SpanContext().TraceID().String())
-		ctx = xlog.NewContextWithJupiterLogger(ctx, xlog.Jupiter(), span.SpanContext().TraceID().String())
+		ctx = xlog.NewContext(ctx, xlog.Default(), span.SpanContext().TraceID().String())
+		ctx = xlog.NewContext(ctx, xlog.Jupiter(), span.SpanContext().TraceID().String())
 
 		return handler(ctx, req)
 	}
@@ -136,8 +136,8 @@ func NewTraceStreamServerInterceptor() grpc.StreamServerInterceptor {
 		ctx, span := tracer.Start(ss.Context(), operation, xtrace.MetadataReaderWriter(md), trace.WithAttributes(attrs...))
 		defer span.End()
 
-		ctx = xlog.NewContextWithDefaultLogger(ctx, xlog.Default(), span.SpanContext().TraceID().String())
-		ctx = xlog.NewContextWithJupiterLogger(ctx, xlog.Jupiter(), span.SpanContext().TraceID().String())
+		ctx = xlog.NewContext(ctx, xlog.Default(), span.SpanContext().TraceID().String())
+		ctx = xlog.NewContext(ctx, xlog.Jupiter(), span.SpanContext().TraceID().String())
 
 		return handler(srv, contextedServerStream{
 			ServerStream: ss,

--- a/pkg/xlog/api.go
+++ b/pkg/xlog/api.go
@@ -22,7 +22,12 @@ import (
 
 // L returns the standard logger.
 func L(ctx context.Context) *Logger {
-	return FromContext(ctx)
+	return GetDefaultLoggerFromContext(ctx)
+}
+
+// J returns the jupiter logger.
+func J(ctx context.Context) *Logger {
+	return GetJupiterLoggerFromContext(ctx)
 }
 
 // Jupiter returns framework logger

--- a/pkg/xlog/api.go
+++ b/pkg/xlog/api.go
@@ -22,12 +22,12 @@ import (
 
 // L returns the standard logger.
 func L(ctx context.Context) *Logger {
-	return GetDefaultLoggerFromContext(ctx)
+	return getDefaultLoggerFromContext(ctx)
 }
 
 // J returns the jupiter logger.
 func J(ctx context.Context) *Logger {
-	return GetJupiterLoggerFromContext(ctx)
+	return getJupiterLoggerFromContext(ctx)
 }
 
 // Jupiter returns framework logger

--- a/pkg/xlog/context.go
+++ b/pkg/xlog/context.go
@@ -42,6 +42,19 @@ func newContextWithJupiterLogger(ctx context.Context, l *Logger, traceID string)
 	return context.WithValue(ctx, jupiterLoggerKey{}, l.With(String(traceIDField, traceID)))
 }
 
+// Deprecated: use xlog.L instead
+func FromContext(ctx context.Context) *Logger {
+	if ctx == nil {
+		return defaultLogger
+	}
+
+	l, ok := ctx.Value(defaultLoggerKey{}).(*Logger)
+	if !ok {
+		return defaultLogger // default logger
+	}
+	return l
+}
+
 func getDefaultLoggerFromContext(ctx context.Context) *Logger {
 	if ctx == nil {
 		return defaultLogger

--- a/pkg/xlog/context.go
+++ b/pkg/xlog/context.go
@@ -27,15 +27,22 @@ type (
 	jupiterLoggerKey struct{}
 )
 
-func NewContextWithDefaultLogger(ctx context.Context, l *Logger, traceID string) context.Context {
+func NewContext(ctx context.Context, l *Logger, traceID string) context.Context {
+	if l == jupiterLogger {
+		return newContextWithJupiterLogger(ctx, l, traceID)
+	}
+	return newContextWithDefaultLogger(ctx, l, traceID)
+}
+
+func newContextWithDefaultLogger(ctx context.Context, l *Logger, traceID string) context.Context {
 	return context.WithValue(ctx, defaultLoggerKey{}, l.With(String(traceIDField, traceID)))
 }
 
-func NewContextWithJupiterLogger(ctx context.Context, l *Logger, traceID string) context.Context {
+func newContextWithJupiterLogger(ctx context.Context, l *Logger, traceID string) context.Context {
 	return context.WithValue(ctx, jupiterLoggerKey{}, l.With(String(traceIDField, traceID)))
 }
 
-func GetDefaultLoggerFromContext(ctx context.Context) *Logger {
+func getDefaultLoggerFromContext(ctx context.Context) *Logger {
 	if ctx == nil {
 		return defaultLogger
 	}
@@ -47,7 +54,7 @@ func GetDefaultLoggerFromContext(ctx context.Context) *Logger {
 	return l
 }
 
-func GetJupiterLoggerFromContext(ctx context.Context) *Logger {
+func getJupiterLoggerFromContext(ctx context.Context) *Logger {
 	if ctx == nil {
 		return jupiterLogger
 	}

--- a/pkg/xlog/context.go
+++ b/pkg/xlog/context.go
@@ -23,21 +23,38 @@ const (
 )
 
 type (
-	loggerKey struct{}
+	defaultLoggerKey struct{}
+	jupiterLoggerKey struct{}
 )
 
-func NewContext(ctx context.Context, l *Logger, traceID string) context.Context {
-	return context.WithValue(ctx, loggerKey{}, l.With(String(traceIDField, traceID)))
+func NewContextWithDefaultLogger(ctx context.Context, l *Logger, traceID string) context.Context {
+	return context.WithValue(ctx, defaultLoggerKey{}, l.With(String(traceIDField, traceID)))
 }
 
-func FromContext(ctx context.Context) *Logger {
+func NewContextWithJupiterLogger(ctx context.Context, l *Logger, traceID string) context.Context {
+	return context.WithValue(ctx, jupiterLoggerKey{}, l.With(String(traceIDField, traceID)))
+}
+
+func GetDefaultLoggerFromContext(ctx context.Context) *Logger {
 	if ctx == nil {
 		return defaultLogger
 	}
 
-	l, ok := ctx.Value(loggerKey{}).(*Logger)
+	l, ok := ctx.Value(defaultLoggerKey{}).(*Logger)
 	if !ok {
 		return defaultLogger // default logger
+	}
+	return l
+}
+
+func GetJupiterLoggerFromContext(ctx context.Context) *Logger {
+	if ctx == nil {
+		return jupiterLogger
+	}
+
+	l, ok := ctx.Value(jupiterLoggerKey{}).(*Logger)
+	if !ok {
+		return jupiterLogger // jupiter logger
 	}
 	return l
 }

--- a/pkg/xlog/log_test.go
+++ b/pkg/xlog/log_test.go
@@ -62,13 +62,13 @@ func Test_log(t *testing.T) {
 func Test_trace(t *testing.T) {
 
 	log := Jupiter()
-	ctx := NewContext(context.TODO(), log, "a:b:c:1")
+	ctx := NewContextWithJupiterLogger(context.TODO(), log, "a:b:c:1")
 
-	stdlog := FromContext(ctx)
-	stdlog.Debug("debug", Any("a", "b"))
-	stdlog.Info("info", Any("a", "b"))
-	stdlog.Warn("warn", Any("a", "b"))
-	stdlog.Error("error", Any("a", "b"))
+	jlog := GetJupiterLoggerFromContext(ctx)
+	jlog.Debug("debug", Any("a", "b"))
+	jlog.Info("info", Any("a", "b"))
+	jlog.Warn("warn", Any("a", "b"))
+	jlog.Error("error", Any("a", "b"))
 
 	data, err := prometheus.DefaultGatherer.Gather()
 	assert.Nil(t, err)

--- a/pkg/xlog/log_test.go
+++ b/pkg/xlog/log_test.go
@@ -62,9 +62,9 @@ func Test_log(t *testing.T) {
 func Test_trace(t *testing.T) {
 
 	log := Jupiter()
-	ctx := NewContextWithJupiterLogger(context.TODO(), log, "a:b:c:1")
+	ctx := NewContext(context.TODO(), log, "a:b:c:1")
 
-	jlog := GetJupiterLoggerFromContext(ctx)
+	jlog := J(ctx)
 	jlog.Debug("debug", Any("a", "b"))
 	jlog.Info("info", Any("a", "b"))
 	jlog.Warn("warn", Any("a", "b"))


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/douyu/jupiter/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
There is no trace id field in the `xecho access log`, but we do need it.

### Describe how you did it
Just replace the default logger in the middleware

### Describe how to verify it
The trace id field is included in the output access log
