### PR TITLE
chore: use res.Body.Bytes() instead of []byte(res.Body.String())

### DIFF
--- a/proto/helloworld/v1/echo_test.go
+++ b/proto/helloworld/v1/echo_test.go
@@ -153,7 +153,7 @@ func TestGreeterService_SayHello_0(t *testing.T) {
 			router.ServeHTTP(res, tt.args.createReq())
 
 			var body bytes.Buffer
-			err := json.Compact(&body, []byte(res.Body.String()))
+			err := json.Compact(&body, res.Body.Bytes())
 			// 如果Compact失败，则说明不是json格式
 			if err != nil {
 				body.WriteString(res.Body.String())

--- a/proto/helloworld/v1/gin_test.go
+++ b/proto/helloworld/v1/gin_test.go
@@ -149,7 +149,7 @@ func TestGinGreeterService_SayHello_0(t *testing.T) {
 			router.ServeHTTP(res, tt.args.createReq())
 
 			var body bytes.Buffer
-			err := json.Compact(&body, []byte(res.Body.String()))
+			err := json.Compact(&body, res.Body.Bytes())
 			// 如果Compact失败，则说明不是json格式
 			if err != nil {
 				body.WriteString(res.Body.String())


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/douyu/jupiter/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
use res.Body.Bytes() instead of []byte(res.Body.String())
### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

### Describe how to verify it

### Special notes for reviews
