### PR TITLE
Feature/add redis cluster

### DIFF
--- a/pkg/client/redis/client.go
+++ b/pkg/client/redis/client.go
@@ -186,14 +186,15 @@ func (config *Config) buildCluster() (*redis.ClusterClient, error) {
 		if config.EnableSentinel {
 			stubClient.AddHook(sentinelInterceptor(config.name, addr, config, config.logger))
 		}
+	}
 
-		if err := stubClient.Ping(context.Background()).Err(); err != nil {
-			if config.OnDialError == "panic" {
-				config.logger.Panic("redis stub client start err: " + err.Error())
-			}
-			config.logger.Error("redis stub client start err", xlog.FieldErr(err))
-			return nil, err
+	stubClient.Ping(context.Background())
+	if err := stubClient.Ping(context.Background()).Err(); err != nil {
+		if config.OnDialError == "panic" {
+			config.logger.Panic("redis stub client start err: " + err.Error())
 		}
+		config.logger.Error("redis stub client start err", xlog.FieldErr(err))
+		return nil, err
 	}
 
 	instances.Store(config.name, &storeRedis{

--- a/pkg/client/redis/config.go
+++ b/pkg/client/redis/config.go
@@ -16,6 +16,13 @@ import (
 
 // Config ...
 type Config struct {
+	// Cluster host:port addresses of Master node
+	Cluster struct {
+		Addr     []string `json:"addr" toml:"addr"`
+		User     string   `json:"user" toml:"user"`
+		Password string   `json:"password" toml:"password"`
+	} `json:"cluster" toml:"cluster"`
+
 	// Master host:port addresses of Master node
 	Master struct {
 		Addr string `json:"addr" toml:"addr"`

--- a/pkg/client/redis/config.go
+++ b/pkg/client/redis/config.go
@@ -115,8 +115,8 @@ func RawConfig(key string) *Config {
 	if config.Master.Addr != "" && config.ReadOnMaster {
 		config.Slaves.Addr = append(config.Slaves.Addr, config.Master.Addr)
 	}
-	if config.Master.Addr == "" && len(config.Slaves.Addr) == 0 {
-		config.logger.Panic("no master or slaves addr set:"+key, xlog.FieldName(key), xlog.FieldExtMessage(config))
+	if config.Master.Addr == "" && len(config.Slaves.Addr) == 0 && len(config.Cluster.Addr) == 0 {
+		config.logger.Panic("no cluster master or slaves addr set:"+key, xlog.FieldName(key), xlog.FieldExtMessage(config))
 	}
 	config.name = key
 	if xdebug.IsDevelopmentMode() {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/douyu/jupiter/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

redis支持集群模式

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

在原生redis-go sdk的基础上接入cluster,修改cluster redis配置的加载方式

cluster配置支持云厂商连接："r-bp1zxszhcgatnx****.redis.rds.aliyuncs.com:6379"


也支持自定义node集群连接： ["127.0.0.1:6379","127.0.0.1:6370","127.0.0.1:6371"]

配置示例：
[jupiter.redis.exampleserver]
    [jupiter.redis.exampleserver.stub]
        debug = false
        maxIdle = 10
        maxActive = 50
        dialTimeout = "2s"
        readTimeout = "2s"
        idleTimeout = "60s"
        enableAccessLog = false
        [jupiter.redis.exampleserver.stub.cluster]
            addr = ["r-bp1zxszhcgatnx****.redis.rds.aliyuncs.com:6379"]   # ["127.0.0.1:6379","127.0.0.1:6370","127.0.0.1:6371"]
            user = "root"
            password = "xxxxxx"

### Describe how to verify it

### Special notes for reviews
