### PR TITLE
fix: queue to exit when mq processing msg panic

### DIFF
--- a/pkg/client/rocketmq/push_consumer.go
+++ b/pkg/client/rocketmq/push_consumer.go
@@ -144,8 +144,7 @@ func (cc *PushConsumer) RegisterSingleMessage(f func(context.Context, *primitive
 				}
 			}
 
-			err := f(ctx, msg)
-			if err != nil {
+			if err := f(ctx, msg); err != nil {
 				xlog.Jupiter().Error("consumer message", zap.Error(err), zap.String("field", cc.name), zap.Any("ext", msg))
 				if cc.EnableTrace && span != nil {
 					span.RecordError(err)
@@ -201,8 +200,7 @@ func (cc *PushConsumer) RegisterBatchMessage(f func(context.Context, ...*primiti
 			}
 		}
 
-		err := f(ctx, msgs...)
-		if err != nil {
+		if err := f(ctx, msgs...); err != nil {
 			xlog.Jupiter().Error("consumer batch message", zap.Error(err), zap.String("field", cc.name))
 			return consumer.ConsumeRetryLater, err
 		}


### PR DESCRIPTION
1. Causing the queue goroutine to exit processing msg panic
![img_v3_027e_2e865395-f8a8-49cc-ae74-53f5c87b164g](https://github.com/douyu/jupiter/assets/38626036/ded31d30-2c71-4959-b505-927e3affa40d)

2. Then should add recover() function to prevent exit and continue process the msg.
<img width="958" alt="image" src="https://github.com/douyu/jupiter/assets/38626036/3fa7f2f5-5eb3-4e5e-a9ab-b37558c339c6">